### PR TITLE
Jenkins version string fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ configurations.all {
     System.setProperty("org.gradle.internal.http.socketTimeout", 120000 as String)
 }
 
+// Fix Jenkins' Git: chmod a file should not be detected as a change and append a '.dirty' to the version
+'git config core.fileMode false'.execute()
 // Pulls version from git tag
 version = minecraftVersion + "-" + gitVersion()
 group = modGroup


### PR DESCRIPTION
Jenkins' Git detects a chmod on `build.gradle` as a file change and subsequently, adds a `.dirty` on the version string. This fix works, but is it too hacky? What do you guys think?